### PR TITLE
Fix for handling enter key event on Google keyboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,6 @@ Use `setTags(...)` to set the initial tags in the group.
 
 To "submit" a new tag as user press "Enter" or tap the blank area of the tag group, also you can "submit" a new tag via `submitTag()`.
 
-**Note**: Google keyboard (a few soft keyboard not honour the key event) currently not supported "Enter" key to "submit" a new tag.
-
 #### How to delete a tag?
 
 To delete a tag as user press "Backspace" key or double-tap the tag which you want to delete.

--- a/library/src/main/java/me/gujun/android/taggroup/TagGroup.java
+++ b/library/src/main/java/me/gujun/android/taggroup/TagGroup.java
@@ -13,6 +13,7 @@ import android.graphics.RectF;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.text.Editable;
+import android.text.InputType;
 import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.text.method.ArrowKeyMovementMethod;

--- a/library/src/main/java/me/gujun/android/taggroup/TagGroup.java
+++ b/library/src/main/java/me/gujun/android/taggroup/TagGroup.java
@@ -736,6 +736,9 @@ public class TagGroup extends ViewGroup {
 
             if (state == STATE_INPUT) {
                 requestFocus();
+                //Replace Enter (new line) button with Action Go
+                setRawInputType(InputType.TYPE_CLASS_TEXT);
+                setImeOptions(EditorInfo.IME_ACTION_GO);
 
                 // Handle the ENTER key down.
                 setOnEditorActionListener(new OnEditorActionListener() {


### PR DESCRIPTION
Replacing Enter button (new line) with an action event on TextView for adding new Tag.
Fixes lack of add key event on Google Keyboard.
